### PR TITLE
ci(actions): Add GitHub actions workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,24 @@
+name: Ultron-gh-actions
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build
+      run: cargo build --verbose
+    - name: Lint
+      run: cargo check --verbose
+    - name: Run tests
+      run: cargo test --verbose


### PR DESCRIPTION
Hi 👋

Showing up, because your repository had an open issue labeled with: `good first issue`. 

This PR is in reference to GitHub Issue #2, and contains the required the boilerplate to enable a GitHub Actions workflow for Rust based projects. By default it runs with verbose enabled.

The current workflow contains:

* A cargo build step
* A cargo check step
* A cargo test step

Hope this helps and good luck with the project 😉